### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+    [push]
+
+jobs:
+    build:
+        name: Build & Test
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Use Node.js 20.16.0
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 20.16.0
+            - run: npm install
+            - run: npm test
+            - run: npm run build:wasm
+            - name: Publish wasm output build artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: tree-sitter-dezyne.wasm
+                path: tree-sitter-dezyne.wasm

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
+    "build:wasm": "npx tree-sitter-cli build --wasm",
     "test": "npx tree-sitter-cli test",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --strip",


### PR DESCRIPTION
Added github CI workflow files that will do the following for each push:

- Check out repo
- Fetch latest node.js LTS version
- Install node dependencies
- Run tests
- Build WASM artifact
- Publish WASM output as build artifact